### PR TITLE
Add 1.18.2 support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -119,19 +119,8 @@ repositories {
             url = "https://maven.blamejared.com/"
         }
         mavenCentral()
-        maven { url = "https://maven.shedaniel.me/" } // Cloth Config, REI
         maven { url = "https://maven.blamejared.com/" } // JEI, Hex Casting
         maven { url = "https://maven.parchmentmc.org" } // Parchment mappings
-        maven { url = "https://maven.quiltmc.org/repository/release" } // Quilt Mappings
-        maven { url = "https://jm.gserv.me/repository/maven-public/" } // JourneyMap API
-        maven { url = "https://api.modrinth.com/maven" } // LazyDFU, JourneyMap
-        maven { // Flywheel
-            url = "https://maven.tterrag.com/"
-            content {
-                // need to be specific here due to version overlaps
-                includeGroup("com.jozufozu.flywheel")
-            }
-        }
 }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ minecraft {
     //
     // Use non-default mappings at your own risk. They may not always work.
     // Simply re-run your setup task after changing the mappings to update your workspace.
-    mappings channel: 'parchment', version: '2022.08.14-1.19.2'
+    mappings channel: 'parchment', version: '2022.11.06-1.18.2'
     // accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg') // Currently, this location cannot be changed from the default.
 
     // Default run configurations.
@@ -109,7 +109,6 @@ minecraft {
 sourceSets.main.resources { srcDir 'src/generated/resources' }
 
 repositories {
-    repositories {
         maven {
             name = 'tterrag maven'
             url = 'https://maven.tterrag.com/'
@@ -119,20 +118,32 @@ repositories {
             name = "Jared's maven"
             url = "https://maven.blamejared.com/"
         }
-    }
+        mavenCentral()
+        maven { url = "https://maven.shedaniel.me/" } // Cloth Config, REI
+        maven { url = "https://maven.blamejared.com/" } // JEI, Hex Casting
+        maven { url = "https://maven.parchmentmc.org" } // Parchment mappings
+        maven { url = "https://maven.quiltmc.org/repository/release" } // Quilt Mappings
+        maven { url = "https://jm.gserv.me/repository/maven-public/" } // JourneyMap API
+        maven { url = "https://api.modrinth.com/maven" } // LazyDFU, JourneyMap
+        maven { // Flywheel
+            url = "https://maven.tterrag.com/"
+            content {
+                // need to be specific here due to version overlaps
+                includeGroup("com.jozufozu.flywheel")
+            }
+        }
 }
 
 
 dependencies {
-    minecraft 'net.minecraftforge:forge:1.19.2-43.2.3'
+    minecraft 'net.minecraftforge:forge:1.18.2-40.2.10'
 
     implementation fg.deobf("com.simibubi.create:create-${create_minecraft_version}:${create_version}:slim") { transitive = false }
     implementation fg.deobf("com.jozufozu.flywheel:flywheel-forge-${flywheel_minecraft_version}:${flywheel_version}")
     implementation fg.deobf("com.tterrag.registrate:Registrate:${registrate_version}")
-    compileOnly(fg.deobf("mezz.jei:jei-${mc_version}-common-api:${jei_version}"))
-    compileOnly(fg.deobf("mezz.jei:jei-${mc_version}-forge-api:${jei_version}"))
+    compileOnly fg.deobf("mezz.jei:jei-${mc_version}:${jei_version}:api")
     // at runtime, use the full JEI jar for Forge
-    runtimeOnly(fg.deobf("mezz.jei:jei-${mc_version}-forge:${jei_version}"))
+    runtimeOnly fg.deobf("mezz.jei:jei-${mc_version}:${jei_version}")
 }
 
 // Example for how to get properties into the manifest for reading at runtime.

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,10 +2,10 @@
 # This is required to provide enough memory for the Minecraft decompilation process.
 org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
-create_minecraft_version = 1.19.2
-flywheel_minecraft_version = 1.19.2
-create_version = 0.5.1.c-36
-flywheel_version = 0.6.9-18
-registrate_version = MC1.19-1.1.5
-mc_version=1.19.2
-jei_version=11.2.0.254
+create_minecraft_version = 1.18.2
+flywheel_minecraft_version = 1.18.2
+create_version = 0.5.1.c-297
+flywheel_version = 0.6.9-101
+registrate_version = MC1.18.2-1.1.3
+mc_version=1.18.2
+jei_version=9.7.0.209

--- a/src/main/java/systems/alexander/bellsandwhistles/BellsAndWhistles.java
+++ b/src/main/java/systems/alexander/bellsandwhistles/BellsAndWhistles.java
@@ -46,6 +46,22 @@ public class BellsAndWhistles {
     public static class ClientModEvents {
         @SubscribeEvent
         public static void onClientSetup(FMLClientSetupEvent event) {
+            ItemBlockRenderTypes.setRenderLayer(ModBlocks.ANDESITE_BOGIE_STEPS.get(), RenderType.cutout());
+            ItemBlockRenderTypes.setRenderLayer(ModBlocks.ANDESITE_DOOR_STEP.get(), RenderType.cutout());
+            ItemBlockRenderTypes.setRenderLayer(ModBlocks.ANDESITE_GRAB_RAILS.get(), RenderType.cutout());
+
+            ItemBlockRenderTypes.setRenderLayer(ModBlocks.BRASS_BOGIE_STEPS.get(), RenderType.cutout());
+            ItemBlockRenderTypes.setRenderLayer(ModBlocks.BRASS_DOOR_STEP.get(), RenderType.cutout());
+            ItemBlockRenderTypes.setRenderLayer(ModBlocks.BRASS_GRAB_RAILS.get(), RenderType.cutout());
+
+            ItemBlockRenderTypes.setRenderLayer(ModBlocks.COPPER_BOGIE_STEPS.get(), RenderType.cutout());
+            ItemBlockRenderTypes.setRenderLayer(ModBlocks.COPPER_DOOR_STEP.get(), RenderType.cutout());
+            ItemBlockRenderTypes.setRenderLayer(ModBlocks.COPPER_GRAB_RAILS.get(), RenderType.cutout());
+
+            ItemBlockRenderTypes.setRenderLayer(ModBlocks.HEADLIGHT.get(), RenderType.cutout());
+            ItemBlockRenderTypes.setRenderLayer(ModBlocks.ORNATE_IRON_TRAPDOOR.get(), RenderType.cutout());
+            ItemBlockRenderTypes.setRenderLayer(ModBlocks.METRO_WINDOW.get(), RenderType.cutout());
+
         }
     }
 }

--- a/src/main/java/systems/alexander/bellsandwhistles/block/ModBlocks.java
+++ b/src/main/java/systems/alexander/bellsandwhistles/block/ModBlocks.java
@@ -16,7 +16,6 @@ import com.tterrag.registrate.builders.BlockBuilder;
 import com.tterrag.registrate.util.entry.BlockEntry;
 import com.tterrag.registrate.util.nullness.NonNullUnaryOperator;
 import net.minecraft.client.renderer.RenderType;
-import net.minecraft.data.CachedOutput;
 import net.minecraft.data.loot.BlockLoot;
 import net.minecraft.sounds.SoundEvent;
 import net.minecraft.tags.ItemTags;

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -1,5 +1,5 @@
 modLoader="javafml" #mandatory
-loaderVersion="[43,)" #mandatory This is typically bumped every Minecraft version by Forge. See our download page for lists of versions.
+loaderVersion="[40,)" #mandatory This is typically bumped every Minecraft version by Forge. See our download page for lists of versions.
 license="MIT"
 # A URL to refer people to when problems occur with this mod
 issueTrackerURL="https://github.com/alexandsr/BellsAndWhistlesMod/issues"
@@ -24,7 +24,7 @@ description='''
     # Does this dependency have to exist - if not, ordering below must be specified
     mandatory=true #mandatory
     # The version range of the dependency
-    versionRange="[43,)" #mandatory
+    versionRange="[40.2.10,)" #mandatory
     # An ordering relationship for the dependency - BEFORE or AFTER required if the relationship is not mandatory
     ordering="NONE"
     # Side this dependency is applied on - BOTH, CLIENT or SERVER
@@ -34,7 +34,7 @@ description='''
     modId="minecraft"
     mandatory=true
 # This version range declares a minimum of the current minecraft version up to but not including the next major version
-    versionRange="[1.19.2,1.20)"
+    versionRange="[1.18.2,)"
     ordering="NONE"
     side="BOTH"
 [[dependencies.bellsandwhistles]]


### PR DESCRIPTION
I updated all settings and build variable to switch to 1.18.2
For some reason my IDE was not finding dependencies so I updated the repositories.
All block with the cutout rendered where rendering with black pixels so I had to specify the rendered in the client setup.
The 'import net.minecraft.data.CachedOutput;' doesn't exist in 1.18.2 but it was not used so I just removed it.